### PR TITLE
Require result to be an integer

### DIFF
--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -86,3 +86,8 @@ test('validEquation is true if result less than 10 and is correct', () => {
   const row = { operandA: 2, operator: '+' as Operator, operandB: 7, result: 9 }
   expect(validEquation(row)).toEqual(true)
 })
+
+test('validEquation is false if result is not an integer', () => {
+  const row = { operandA: 2, operator: '+' as Operator, operandB: 5.5, result: 7.5 }
+  expect(validEquation(row)).toEqual(false)
+})

--- a/src/core.ts
+++ b/src/core.ts
@@ -123,7 +123,7 @@ function getResult(operandA: number, operator: Operator, operandB: number): numb
 export function validEquation(row: Row): boolean {
   if (row.operandA !== undefined && row.operator !== undefined && row.operandB !== undefined) {
     const correctResult = getResult(row.operandA, row.operator, row.operandB)
-    return correctResult < 10 && correctResult === row.result
+    return Number.isInteger(correctResult) && correctResult < 10 && correctResult === row.result
   } else {
     return false
   }
@@ -147,5 +147,4 @@ export function isFunAnswer(row: Answer): boolean {
     case '%':
       return row.operandA !== 0 && row.operandB !== 1
   }
-  return true
 }


### PR DESCRIPTION
Now that I'm not generating an integer result, it's possible for it to be a decimal (e.g. `9 / 6 = 1.5`).

This makes those types of equations invalid so it'll generate a valid one instead.

Closes https://github.com/iancanderson/hurdle/issues/23